### PR TITLE
revert: reinstate userdata database

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -21,6 +21,7 @@ ynh_backup "/etc/systemd/system/$app.service"
 #=================================================
 ynh_print_info "Backing up the postgresql database..."
 
+ynh_psql_dump_db "$userdata_db_name" > ./userdb.sql
 ynh_psql_dump_db > ./db.sql
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -37,6 +37,19 @@ pushd $install_dir
 popd
 
 #=================================================
+# CREATE AN ADDITIONAL DATABASE FOR USER DATA
+#=================================================
+
+userdata_db_user=${app}_userdata
+userdata_db_name=$userdata_db_user
+userdata_db_pwd=$(ynh_string_random)
+ynh_psql_create_user "$userdata_db_user" "$userdata_db_pwd"
+ynh_psql_create_db "$userdata_db_name" "$userdata_db_user"
+ynh_app_setting_set --key=userdata_db_user --value=$userdata_db_user
+ynh_app_setting_set --key=userdata_db_name --value=$userdata_db_name
+ynh_app_setting_set --key=userdata_db_pwd --value=$userdata_db_pwd
+
+#=================================================
 # SYSTEM CONFIGURATION
 #=================================================
 ynh_script_progression "Adding system configurations related to $app..."

--- a/scripts/restore
+++ b/scripts/restore
@@ -18,6 +18,9 @@ ynh_restore "$install_dir"
 #=================================================
 ynh_script_progression "Restoring the PostgreSQL database..."
 
+ynh_psql_create_user "$userdata_db_user" "$userdata_db_pwd"
+ynh_psql_create_db "$userdata_db_name" "$userdata_db_user"
+ynh_psql_db_shell < ./userdb.sql
 ynh_psql_db_shell < ./db.sql
 
 #=================================================


### PR DESCRIPTION
A previous cleanup removed the specific code needed to add a second database dedicated to user data for this app. Let's reinstate it.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
